### PR TITLE
Fix compilation error in UE5.1

### DIFF
--- a/RustPlugin/Source/RustPlugin/Private/RustProperty.cpp
+++ b/RustPlugin/Source/RustPlugin/Private/RustProperty.cpp
@@ -147,7 +147,7 @@ void FDynamicRustComponent::Render(TSharedRef<IPropertyHandle> MapHandle, IDetai
 					.ContentPadding(0)
 					[
 						SNew(SImage)
-						.Image(FEditorStyle::GetBrush("Icons.Delete"))
+						.Image(FAppStyle::GetBrush("Icons.Delete"))
 						.ColorAndOpacity(FSlateColor::UseForeground())
 					]
 				]


### PR DESCRIPTION
Compilation is failing because `FEditorStyle` doesn't exist, adding `#include "EditorStyleSet.h"` would fix this but as it's been deprecated switching to `FAppStyle.GetBrush()` seems to be the sensible option.